### PR TITLE
fix: remove pretty option from dump channels

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -25,7 +25,7 @@ workflow {
         params.annotations
     )
     ch_reads_raw    = PREPARE_INPUTS.out.samples
-    ch_reads_raw.dump(tag: "ch_reads_raw", pretty: true)
+    ch_reads_raw.dump(tag: "ch_reads_raw")
     ch_genome       = PREPARE_INPUTS.out.genome
     ch_genome_index = PREPARE_INPUTS.out.genome_index
     ch_annotations  = PREPARE_INPUTS.out.annotations

--- a/setup.nf
+++ b/setup.nf
@@ -67,7 +67,7 @@ workflow WRITE_SAMPLESHEET {
         Channel
             .fromFilePairs("${reads_dir}/*_R{1,2}_001.fastq.gz", size: -1, checkIfExists: true)
             .set { ch_readPairs }
-        ch_readPairs.dump(tag: "ch_readPairs", pretty: true)
+        ch_readPairs.dump(tag: "ch_readPairs")
 
         // cast ch_readPairs to a map and write to a file
         ch_readPairs

--- a/subworkflows/group_reads.nf
+++ b/subworkflows/group_reads.nf
@@ -10,7 +10,7 @@ workflow Group_Reads {
             }
             .groupTuple()
             .map { reshapeGroupedLaneReads(it) }
-            .dump(tag: "ch_reads_grouped", pretty: true)
+            .dump(tag: "ch_reads_grouped")
             .set { ch_reads_grouped }
 
     emit:


### PR DESCRIPTION
The pretty option throws errors with the nextflow version available
through loading the ISAAC Nextflow module.