### PR TITLE
change: read groups

### DIFF
--- a/lib/ReadGroup.groovy
+++ b/lib/ReadGroup.groovy
@@ -2,7 +2,41 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
 
-static def buildBwaMem2RGLine(rgFields) {
+/**
+ * Build the read group line for the specified tool from a map of read group fields.
+ *
+ * Most tools (typically mapping tools but I'm not making any assumptions here) have the ability to add read group information that is specified as a command line argument.
+ * Most of these tools expect the read group argument to be in slightly different formats.
+ * The purpose of this method is to build the read group line of argument for a specific command line tool.
+ *
+ * @params LinkedHashMap rgFields A map of read group fields as tag:value pairs. First field must be ID.
+ * @params String tool The tool to build a read group line for.
+ *
+ * @return String Read group line.
+ */
+public static String buildRGLine(rgFields, tool) {
+    String rgLine = ''
+    switch (tool) {
+        case 'bwa-mem2':
+            rgLine = buildBwaMem2RGLine(rgFields)
+            break
+
+        case 'star':
+            rgLine = buildSTARRGLine(rgFields)
+            break
+    }
+
+    return rgLine
+}
+
+/**
+ * Build the read group line for bwa-mem2 from a map of read group fields.
+ *
+ * @params LinkedHashMap rgFields A map of read group fields as tag:value pairs. First field must be ID.
+ *
+ * @return String Read group line for bwa-mem2.
+ */
+private static String buildBwaMem2RGLine(rgFields) {
     ArrayList rgLineElements = ['@RG']
 
     rgFields.each { tag, value ->
@@ -12,7 +46,14 @@ static def buildBwaMem2RGLine(rgFields) {
     return rgLineElements.join('\t')
 }
 
-static String buildSTARRGLine(rgFields) {
+/**
+ * Build the read group line for STAR from a map of read group fields.
+ *
+ * @params LinkedHashMap rgFields A map of read group fields as tag:value pairs. First field must be ID.
+ *
+ * @return String Read group line for STAR.
+ */
+private static String buildSTARRGLine(rgFields) {
     ArrayList rgLineElements = []
 
     rgFields.each { tag, value ->

--- a/lib/ReadGroup.groovy
+++ b/lib/ReadGroup.groovy
@@ -2,6 +2,16 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
 
+static def buildBwaMem2RGLine(rgFields) {
+    ArrayList rgLineElements = ['@RG']
+
+    rgFields.each { tag, value ->
+        rgLineElements += "${tag}:${value}"
+    }
+
+    return rgLineElements.join('\t')
+}
+
 /**
  * Build the read group fields from sample metadata and matcher data from the sequence identifier.
  *

--- a/lib/ReadGroup.groovy
+++ b/lib/ReadGroup.groovy
@@ -12,6 +12,16 @@ static def buildBwaMem2RGLine(rgFields) {
     return rgLineElements.join('\t')
 }
 
+static String buildSTARRGLine(rgFields) {
+    ArrayList rgLineElements = []
+
+    rgFields.each { tag, value ->
+        rgLineElements += "${tag}:${value}"
+    }
+
+    return rgLineElements.join(' ')
+}
+
 /**
  * Build the read group fields from sample metadata and matcher data from the sequence identifier.
  *

--- a/lib/ReadGroup.groovy
+++ b/lib/ReadGroup.groovy
@@ -3,37 +3,32 @@ import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
 
 /**
- * Build the read group line from sample metadata and matcher data from the sequence identifier.
+ * Build the read group fields from sample metadata and matcher data from the sequence identifier.
  *
  * @params LinkedHashMap metadata A metadata map.
  * @params Matcher matcher A matcher object of sequence identifier.
  *
- * @return String A tab-separated formatted RG line
+ * @return LinkedHashMap Read group fields containing at least ID, SM, LB, and PL fields.
  */
-static String buildRGLine(metadata, matcher) {
-    ArrayList rgFields = ['@RG']
-    def rgID = ''
-    def rgPU = ''
+static LinkedHashMap buildRGFields(metadata, matcher) {
+    def rgFields = [:]
 
-    // add dynamically determined read group fields
-    // this includes ID and PU
+    // add dynamically determined read group fields -- ID and PU
     if(matcher.find()) {
-        rgID = "${matcher.group('instrument')}_${matcher.group('runNumber')}_${matcher.group('flowcellID')}.${matcher.group('lane')}"
-        rgPU = "${matcher.group('flowcellID')}.${matcher.group('lane')}.${matcher.group('index')}"
+        rgFields += ['ID': "${matcher.group('instrument')}_${matcher.group('runNumber')}_${matcher.group('flowcellID')}.${matcher.group('lane')}"]
+        rgFields += ['PU': "${matcher.group('flowcellID')}.${matcher.group('lane')}.${matcher.group('index')}"]
     } else {
-        rgID = "${metadata.sampleName}.${metadata.lane}"
+        rgFields += ['ID': "${metadata.sampleName}.${metadata.lane}"]
     }
-    rgFields += "ID:${rgID}"
-    if(rgPU) rgFields += "PU:${rgPU}"
 
-    // add more straightforwardly determined fields
-    rgFields += "SM:${metadata.sampleName}"
-    rgFields += "LB:${metadata.sampleName}"
+    // add more straightforwardly determined dynamic fields
+    rgFields += ['SM': "${metadata.sampleName}"]
+    rgFields += ['LB': "${metadata.sampleName}"]
 
     // add static fields
-    rgFields += "PL:ILLUMINA"
+    rgFields += ['PL': "ILLUMINA"]
 
-    return rgFields.join('\t')
+    return rgFields
 }
 
 /**

--- a/modules/bwa_mem2_mem.nf
+++ b/modules/bwa_mem2_mem.nf
@@ -35,7 +35,7 @@ process bwa_mem2_mem {
         String stemName = MetadataUtils.buildStemName(metadata)
 
         // build read group line
-        String rgLine = ReadGroup.buildBwaMem2RGLine(metadata.rgFields)
+        String rgLine = ReadGroup.buildRGLine(metadata.rgFields, 'bwa-mem2')
 
         """
         bwa-mem2 mem \

--- a/modules/bwa_mem2_mem.nf
+++ b/modules/bwa_mem2_mem.nf
@@ -34,9 +34,12 @@ process bwa_mem2_mem {
         // set stem name
         String stemName = MetadataUtils.buildStemName(metadata)
 
+        // build read group line
+        String rgLine = ReadGroup.buildBwaMem2RGLine(metadata.rgFields)
+
         """
         bwa-mem2 mem \
-            -R "${metadata.rgLine}" \
+            -R "${rgLine}" \
             -t ${task.cpus} \
             ${indexPrefix} \
             ${reads} \

--- a/modules/star_runMapping.nf
+++ b/modules/star_runMapping.nf
@@ -31,8 +31,8 @@ process star_runMapping {
         // set stem name
         String stemName = MetadataUtils.buildStemName(metadata)
 
-        // fix RG line
-        String rgLine = metadata.rgLine.replaceFirst(/^@RG\t/, '')
+        // build read group line
+        String rgLine = ReadGroup.buildSTARRGLine(metadata.rgFields)
         
         """
         STAR \

--- a/modules/star_runMapping.nf
+++ b/modules/star_runMapping.nf
@@ -32,7 +32,7 @@ process star_runMapping {
         String stemName = MetadataUtils.buildStemName(metadata)
 
         // build read group line
-        String rgLine = ReadGroup.buildSTARRGLine(metadata.rgFields)
+        String rgLine = ReadGroup.buildRGLine(metadata.rgFields, 'star')
         
         """
         STAR \

--- a/subworkflows/parse_samplesheet.nf
+++ b/subworkflows/parse_samplesheet.nf
@@ -44,7 +44,7 @@ def createSampleReadsChannel(LinkedHashMap row) {
     // get sequence ID line from fastq.gz
     def sequenceIdentifier = ReadGroup.readFastqFirstSequenceIdentifier(reads1)
     def sequenceIdentifierMatcher = ReadGroup.matchSequenceIdentifier(sequenceIdentifier)
-    metadata.rgLine = ReadGroup.buildRGLine(metadata, sequenceIdentifierMatcher)
+    metadata.rgFields = ReadGroup.buildRGFields(metadata, sequenceIdentifierMatcher)
 
     return [ metadata, reads1, reads2 ]
 }

--- a/tests/lib/Reads.groovy
+++ b/tests/lib/Reads.groovy
@@ -45,6 +45,13 @@ abstract class Reads {
         ]
     }
 
+    public getRGLine() {
+        def rgFields = this.getRGFields()
+
+
+        "@RG\tID:${rgFields.get('ID')}\tSM:${rgFields.get('SM')}\tLB:${rgFields.get('LB')}\tPL:${rgFields.get('PL')}"
+    }
+
     public getR1SimpleName() {
         // regexp pattern that matches common fastq filename endings
         // matches: fastq.gz, fq.gz, fastq, fq

--- a/tests/lib/Reads.groovy
+++ b/tests/lib/Reads.groovy
@@ -36,8 +36,13 @@ abstract class Reads {
         "${this.getSampleName()}_L${this.getLane()}"
     }
 
-    public getRGLine() {
-        "@RG\tID:${this.getSampleName()}.${this.getLane()}\tSM:${this.getSampleName()}\tLB:${this.getSampleName()}\tPL:ILLUMINA"
+    public getRGFields() {
+        [
+            'ID': "${this.getSampleName()}.${this.getLane()}",
+            'SM': "${this.getSampleName()}",
+            'LB': "${this.getSampleName()}",
+            'PL': 'ILLUMINA'
+        ]
     }
 
     public getR1SimpleName() {

--- a/tests/subworkflows/bwa_mem2.nf.test
+++ b/tests/subworkflows/bwa_mem2.nf.test
@@ -22,7 +22,12 @@ nextflow_workflow {
                         sampleNumber: "${readsLane1.getSampleNumber()}",
                         lane:         "${readsLane1.getLane()}",
                         readType:     "${readsLane1.getReadType()}",
-                        rgLine:       "${readsLane1.getRGLine()}"
+                        rgFields:     [
+                            ID: "${readsLane1.getRGFields().get('ID')}",
+                            SM: "${readsLane1.getRGFields().get('SM')}",
+                            LB: "${readsLane1.getRGFields().get('LB')}",
+                            PL: "${readsLane1.getRGFields().get('PL')}",
+                        ]
                     ],
                     file("${readsLane1.getR1()}"),
                     file("${readsLane1.getR2()}")
@@ -70,7 +75,12 @@ nextflow_workflow {
                         sampleNumber: "${readsLane1.getSampleNumber()}",
                         lane:         "${readsLane1.getLane()}",
                         readType:     "${readsLane1.getReadType()}",
-                        rgLine:       "${readsLane1.getRGLine()}"
+                        rgFields:     [
+                            ID: "${readsLane1.getRGFields().get('ID')}",
+                            SM: "${readsLane1.getRGFields().get('SM')}",
+                            LB: "${readsLane1.getRGFields().get('LB')}",
+                            PL: "${readsLane1.getRGFields().get('PL')}",
+                        ]
                     ],
                     file("${readsLane1.getR1()}"),
                     file("${readsLane1.getR2()}")

--- a/tests/subworkflows/bwa_mem2.nf.test.snap
+++ b/tests/subworkflows/bwa_mem2.nf.test.snap
@@ -9,7 +9,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.sam:md5,7111ddc8b9797a0e4d04bffaa5c5be34"
                     ]
@@ -21,14 +26,19 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.sam:md5,7111ddc8b9797a0e4d04bffaa5c5be34"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-10-17T09:33:52.618514402"
+        "timestamp": "2023-10-30T11:32:27.697108492"
     },
     "Bwa_Mem2 builds index and aligns reads -- PE reads.": {
         "content": [
@@ -40,7 +50,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.sam:md5,1c13b95ac563b45f8d2b7f3789ce8bd4"
                     ]
@@ -52,13 +67,18 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.sam:md5,1c13b95ac563b45f8d2b7f3789ce8bd4"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-10-17T09:34:04.173682776"
+        "timestamp": "2023-10-30T11:32:38.961222639"
     }
 }

--- a/tests/subworkflows/parse_samplesheet.nf.test
+++ b/tests/subworkflows/parse_samplesheet.nf.test
@@ -220,7 +220,7 @@ nextflow_workflow {
                         assert readType     == 'single'
                         assert sampleNumber == '3'
                         assert lane         == '001'
-                        assert rgLine       == readsSELane1.getRGLine()
+                        assert rgFields       == readsSELane1.getRGFields()
                     }
                     // test R1
                     assert get(1) ==~ /^.*\/SRR1066657_S3_L001_R1_001\.fastq\.gz/
@@ -234,7 +234,7 @@ nextflow_workflow {
                         assert readType     == 'single'
                         assert sampleNumber == '3'
                         assert lane         == '002'
-                        assert rgLine       == readsSELane2.getRGLine()
+                        assert rgFields       == readsSELane2.getRGFields()
                     }
                     // test R1
                     assert get(1) ==~ /^.*\/SRR1066657_S3_L002_R1_001\.fastq\.gz/
@@ -248,7 +248,7 @@ nextflow_workflow {
                         assert readType     == 'paired'
                         assert sampleNumber == '1'
                         assert lane         == '001'
-                        assert rgLine       == readsPELane1.getRGLine()
+                        assert rgFields       == readsPELane1.getRGFields()
                     }
                     // test R1
                     assert get(1) ==~ /^.*\/SRR6924569_S1_L001_R1_001\.fastq\.gz/
@@ -262,7 +262,7 @@ nextflow_workflow {
                         assert readType     == 'paired'
                         assert sampleNumber == '1'
                         assert lane         == '002'
-                        assert rgLine       == readsPELane2.getRGLine()
+                        assert rgFields       == readsPELane2.getRGFields()
                     }
                     // test R1
                     assert get(1) ==~ /^.*\/SRR6924569_S1_L002_R1_001\.fastq\.gz/

--- a/tests/subworkflows/parse_samplesheet.nf.test.snap
+++ b/tests/subworkflows/parse_samplesheet.nf.test.snap
@@ -8,7 +8,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -18,7 +23,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -28,7 +38,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -38,7 +53,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -50,7 +70,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -60,7 +85,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -70,7 +100,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -80,7 +115,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -88,7 +128,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-24T15:59:49.318184686"
+        "timestamp": "2023-10-30T10:27:15.076039967"
     },
     "successfully creates channels from single-end samplesheet.": {
         "content": [
@@ -146,7 +186,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -156,7 +201,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -168,7 +218,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -178,7 +233,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -186,7 +246,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-24T15:59:35.724145481"
+        "timestamp": "2023-10-30T10:27:04.730077808"
     },
     "Parse_Design successfully creates read channels with lanes and sample numbers -- SE + PE reads.": {
         "content": [
@@ -322,7 +382,12 @@
                             "readType": "single",
                             "sampleNumber": "3",
                             "lane": "001",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR1066657_S3_L001_R1_001.fastq.gz",
                         "SRR1066657_S3_L001_R1_001.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -334,7 +399,12 @@
                             "readType": "single",
                             "sampleNumber": "3",
                             "lane": "002",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR1066657_S3_L002_R1_001.fastq.gz",
                         "SRR1066657_S3_L002_R1_001.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -346,7 +416,12 @@
                             "readType": "paired",
                             "sampleNumber": "1",
                             "lane": "001",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L001_R1_001.fastq.gz",
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L001_R2_001.fastq.gz"
@@ -358,7 +433,12 @@
                             "readType": "paired",
                             "sampleNumber": "1",
                             "lane": "002",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L002_R1_001.fastq.gz",
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L002_R2_001.fastq.gz"
@@ -372,7 +452,12 @@
                             "readType": "single",
                             "sampleNumber": "3",
                             "lane": "001",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR1066657_S3_L001_R1_001.fastq.gz",
                         "SRR1066657_S3_L001_R1_001.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -384,7 +469,12 @@
                             "readType": "single",
                             "sampleNumber": "3",
                             "lane": "002",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR1066657_S3_L002_R1_001.fastq.gz",
                         "SRR1066657_S3_L002_R1_001.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -396,7 +486,12 @@
                             "readType": "paired",
                             "sampleNumber": "1",
                             "lane": "001",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L001_R1_001.fastq.gz",
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L001_R2_001.fastq.gz"
@@ -408,7 +503,12 @@
                             "readType": "paired",
                             "sampleNumber": "1",
                             "lane": "002",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L002_R1_001.fastq.gz",
                         "/utia-gc/ngs-test/raw/ngs/data/reads/raw/SRR6924569_S1_L002_R2_001.fastq.gz"
@@ -416,7 +516,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-24T15:59:57.238985963"
+        "timestamp": "2023-10-30T10:27:21.843160652"
     },
     "successfully creates read channels from single-end samplesheet.": {
         "content": [
@@ -691,7 +791,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -701,7 +806,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -713,7 +823,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -723,7 +838,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -731,7 +851,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-24T15:59:42.542606226"
+        "timestamp": "2023-10-30T10:27:09.845104205"
     },
     "successfully creates read channels from mixed single-end and paired-end samplesheet.": {
         "content": [

--- a/tests/subworkflows/star.nf.test
+++ b/tests/subworkflows/star.nf.test
@@ -23,7 +23,12 @@ nextflow_workflow {
                         sampleNumber: "${readsLane1.getSampleNumber()}",
                         lane:         "${readsLane1.getLane()}",
                         readType:     "${readsLane1.getReadType()}",
-                        rgLine:       "${readsLane1.getRGLine()}"
+                        rgFields:     [
+                            ID: "${readsLane1.getRGFields().get('ID')}",
+                            SM: "${readsLane1.getRGFields().get('SM')}",
+                            LB: "${readsLane1.getRGFields().get('LB')}",
+                            PL: "${readsLane1.getRGFields().get('PL')}",
+                        ]
                     ],
                     file("${readsLane1.getR1()}"),
                     file("${readsLane1.getR2()}")
@@ -71,7 +76,12 @@ nextflow_workflow {
                         sampleNumber: "${readsLane1.getSampleNumber()}",
                         lane:         "${readsLane1.getLane()}",
                         readType:     "${readsLane1.getReadType()}",
-                        rgLine:       "${readsLane1.getRGLine()}"
+                        rgFields:     [
+                            ID: "${readsLane1.getRGFields().get('ID')}",
+                            SM: "${readsLane1.getRGFields().get('SM')}",
+                            LB: "${readsLane1.getRGFields().get('LB')}",
+                            PL: "${readsLane1.getRGFields().get('PL')}",
+                        ]
                     ],
                     file("${readsLane1.getR1()}"),
                     file("${readsLane1.getR2()}")

--- a/tests/subworkflows/star.nf.test.snap
+++ b/tests/subworkflows/star.nf.test.snap
@@ -9,7 +9,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001_Aligned.out.sam:md5,9da9e8e690cec3daed1f984d1d3077c4"
                     ]
@@ -21,14 +26,19 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001_Aligned.out.sam:md5,9da9e8e690cec3daed1f984d1d3077c4"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-10-26T15:09:55.546441715"
+        "timestamp": "2023-10-30T11:50:00.875088039"
     },
     "Star builds index and aligns reads -- SE reads.": {
         "content": [
@@ -40,7 +50,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001_Aligned.out.sam:md5,368220688fe7cec495fede5748e075c4"
                     ]
@@ -52,13 +67,18 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001_Aligned.out.sam:md5,368220688fe7cec495fede5748e075c4"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-10-26T15:06:42.559846502"
+        "timestamp": "2023-10-30T11:46:19.80524137"
     }
 }

--- a/tests/workflows/map_reads.nf.test
+++ b/tests/workflows/map_reads.nf.test
@@ -24,7 +24,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane1.getSampleNumber()}",
                             lane:         "${readsLane1.getLane()}",
                             readType:     "${readsLane1.getReadType()}",
-                            rgLine:       "${readsLane1.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane1.getRGFields().get('ID')}",
+                                SM: "${readsLane1.getRGFields().get('SM')}",
+                                LB: "${readsLane1.getRGFields().get('LB')}",
+                                PL: "${readsLane1.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane1.getR1()}"),
                         file("${readsLane1.getR2()}")
@@ -35,7 +40,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane2.getSampleNumber()}",
                             lane:         "${readsLane2.getLane()}",
                             readType:     "${readsLane2.getReadType()}",
-                            rgLine:       "${readsLane2.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane2.getRGFields().get('ID')}",
+                                SM: "${readsLane2.getRGFields().get('SM')}",
+                                LB: "${readsLane2.getRGFields().get('LB')}",
+                                PL: "${readsLane2.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane2.getR1()}"),
                         file("${readsLane2.getR2()}")
@@ -112,7 +122,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane1.getSampleNumber()}",
                             lane:         "${readsLane1.getLane()}",
                             readType:     "${readsLane1.getReadType()}",
-                            rgLine:       "${readsLane1.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane1.getRGFields().get('ID')}",
+                                SM: "${readsLane1.getRGFields().get('SM')}",
+                                LB: "${readsLane1.getRGFields().get('LB')}",
+                                PL: "${readsLane1.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane1.getR1()}"),
                         file("${readsLane1.getR2()}")
@@ -123,7 +138,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane2.getSampleNumber()}",
                             lane:         "${readsLane2.getLane()}",
                             readType:     "${readsLane2.getReadType()}",
-                            rgLine:       "${readsLane2.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane2.getRGFields().get('ID')}",
+                                SM: "${readsLane2.getRGFields().get('SM')}",
+                                LB: "${readsLane2.getRGFields().get('LB')}",
+                                PL: "${readsLane2.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane2.getR1()}"),
                         file("${readsLane2.getR2()}")
@@ -200,7 +220,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane1.getSampleNumber()}",
                             lane:         "${readsLane1.getLane()}",
                             readType:     "${readsLane1.getReadType()}",
-                            rgLine:       "${readsLane1.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane1.getRGFields().get('ID')}",
+                                SM: "${readsLane1.getRGFields().get('SM')}",
+                                LB: "${readsLane1.getRGFields().get('LB')}",
+                                PL: "${readsLane1.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane1.getR1()}"),
                         file("${readsLane1.getR2()}")
@@ -211,7 +236,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane2.getSampleNumber()}",
                             lane:         "${readsLane2.getLane()}",
                             readType:     "${readsLane2.getReadType()}",
-                            rgLine:       "${readsLane2.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane2.getRGFields().get('ID')}",
+                                SM: "${readsLane2.getRGFields().get('SM')}",
+                                LB: "${readsLane2.getRGFields().get('LB')}",
+                                PL: "${readsLane2.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane2.getR1()}"),
                         file("${readsLane2.getR2()}")
@@ -288,7 +318,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane1.getSampleNumber()}",
                             lane:         "${readsLane1.getLane()}",
                             readType:     "${readsLane1.getReadType()}",
-                            rgLine:       "${readsLane1.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane1.getRGFields().get('ID')}",
+                                SM: "${readsLane1.getRGFields().get('SM')}",
+                                LB: "${readsLane1.getRGFields().get('LB')}",
+                                PL: "${readsLane1.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane1.getR1()}"),
                         file("${readsLane1.getR2()}")
@@ -299,7 +334,12 @@ nextflow_workflow {
                             sampleNumber: "${readsLane2.getSampleNumber()}",
                             lane:         "${readsLane2.getLane()}",
                             readType:     "${readsLane2.getReadType()}",
-                            rgLine:       "${readsLane2.getRGLine()}"
+                            rgFields:     [
+                                ID: "${readsLane2.getRGFields().get('ID')}",
+                                SM: "${readsLane2.getRGFields().get('SM')}",
+                                LB: "${readsLane2.getRGFields().get('LB')}",
+                                PL: "${readsLane2.getRGFields().get('PL')}",
+                            ]
                         ],
                         file("${readsLane2.getR1()}"),
                         file("${readsLane2.getR2()}")

--- a/tests/workflows/map_reads.nf.test.snap
+++ b/tests/workflows/map_reads.nf.test.snap
@@ -9,7 +9,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.bam:md5,84a6259469927439f1c1b120e77fa5d8",
                         "SRR1066657_L001.bam.bai:md5,fa09355ba8126b7666351838eff70751"
@@ -20,7 +25,12 @@
                             "sampleNumber": "3",
                             "lane": "002",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L002.bam:md5,7abeac9fe62740928701db106d5a8f80",
                         "SRR1066657_L002.bam.bai:md5,6151f3a8699b203e24e92daf69af0d7e"
@@ -44,7 +54,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.bam:md5,84a6259469927439f1c1b120e77fa5d8",
                         "SRR1066657_L001.bam.bai:md5,fa09355ba8126b7666351838eff70751"
@@ -55,7 +70,12 @@
                             "sampleNumber": "3",
                             "lane": "002",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L002.bam:md5,7abeac9fe62740928701db106d5a8f80",
                         "SRR1066657_L002.bam.bai:md5,6151f3a8699b203e24e92daf69af0d7e"
@@ -74,7 +94,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-26T15:23:20.514849266"
+        "timestamp": "2023-10-30T12:15:34.68083814"
     },
     "MAP_READS maps reads to a reference genome and outputs sorted BAMs -- bwa-mem2 + SE reads.": {
         "content": [
@@ -86,7 +106,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.bam:md5,4127b2dd883040a440d62b90ca52cf65",
                         "SRR1066657_L001.bam.bai:md5,310e773f12ef2ee2041417625519058c"
@@ -97,7 +122,12 @@
                             "sampleNumber": "3",
                             "lane": "002",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L002.bam:md5,cf4a89405d61a82c011e17533ac22116",
                         "SRR1066657_L002.bam.bai:md5,feed2c18a1adcc626a92d3f25d6c8fdb"
@@ -121,7 +151,12 @@
                             "sampleNumber": "3",
                             "lane": "001",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.001\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.001",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L001.bam:md5,4127b2dd883040a440d62b90ca52cf65",
                         "SRR1066657_L001.bam.bai:md5,310e773f12ef2ee2041417625519058c"
@@ -132,7 +167,12 @@
                             "sampleNumber": "3",
                             "lane": "002",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657.002\tSM:SRR1066657\tLB:SRR1066657\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657.002",
+                                "SM": "SRR1066657",
+                                "LB": "SRR1066657",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR1066657_L002.bam:md5,cf4a89405d61a82c011e17533ac22116",
                         "SRR1066657_L002.bam.bai:md5,feed2c18a1adcc626a92d3f25d6c8fdb"
@@ -151,7 +191,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-19T11:42:28.71189115"
+        "timestamp": "2023-10-30T12:13:52.271377328"
     },
     "MAP_READS maps reads to a reference genome and outputs sorted BAMs -- bwa-mem2 + PE reads.": {
         "content": [
@@ -163,7 +203,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.bam:md5,34739d31119b05ae752e830d60a1a211",
                         "SRR6924569_L001.bam.bai:md5,1e9ba5912083c49a1cd61a4556b3b7e4"
@@ -174,7 +219,12 @@
                             "sampleNumber": "1",
                             "lane": "002",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L002.bam:md5,91ffdeef04cc4e98d935e0ddf58c9575",
                         "SRR6924569_L002.bam.bai:md5,70e5ded34544598a2f21ca31ad56179b"
@@ -198,7 +248,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.bam:md5,34739d31119b05ae752e830d60a1a211",
                         "SRR6924569_L001.bam.bai:md5,1e9ba5912083c49a1cd61a4556b3b7e4"
@@ -209,7 +264,12 @@
                             "sampleNumber": "1",
                             "lane": "002",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L002.bam:md5,91ffdeef04cc4e98d935e0ddf58c9575",
                         "SRR6924569_L002.bam.bai:md5,70e5ded34544598a2f21ca31ad56179b"
@@ -228,7 +288,7 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-19T11:42:52.826305658"
+        "timestamp": "2023-10-30T12:14:21.465504219"
     },
     "MAP_READS maps reads to a reference genome and outputs sorted BAMs -- STAR + PE reads.": {
         "content": [
@@ -240,7 +300,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.bam:md5,6c15cc278e607bb09f3755fe928c659e",
                         "SRR6924569_L001.bam.bai:md5,3ae744447ddbb4ed67235d29dcaa6b64"
@@ -251,7 +316,12 @@
                             "sampleNumber": "1",
                             "lane": "002",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L002.bam:md5,3f8d51e4ff0e5ac57c88d5832503f2ef",
                         "SRR6924569_L002.bam.bai:md5,e9d7771744655c8ecc5b1c64b454c765"
@@ -275,7 +345,12 @@
                             "sampleNumber": "1",
                             "lane": "001",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.001\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.001",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L001.bam:md5,6c15cc278e607bb09f3755fe928c659e",
                         "SRR6924569_L001.bam.bai:md5,3ae744447ddbb4ed67235d29dcaa6b64"
@@ -286,7 +361,12 @@
                             "sampleNumber": "1",
                             "lane": "002",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569.002\tSM:SRR6924569\tLB:SRR6924569\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569.002",
+                                "SM": "SRR6924569",
+                                "LB": "SRR6924569",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "SRR6924569_L002.bam:md5,3f8d51e4ff0e5ac57c88d5832503f2ef",
                         "SRR6924569_L002.bam.bai:md5,e9d7771744655c8ecc5b1c64b454c765"
@@ -305,6 +385,6 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-26T15:27:15.113179426"
+        "timestamp": "2023-10-30T12:19:35.81255081"
     }
 }

--- a/tests/workflows/prepare_inputs.nf.test.snap
+++ b/tests/workflows/prepare_inputs.nf.test.snap
@@ -8,7 +8,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -18,7 +23,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -28,7 +38,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -38,7 +53,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -68,7 +88,12 @@
                             "sampleName": "SRR1066657_GSM1299413_WT_NR_A",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066657_GSM1299413_WT_NR_A.null\tSM:SRR1066657_GSM1299413_WT_NR_A\tLB:SRR1066657_GSM1299413_WT_NR_A\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066657_GSM1299413_WT_NR_A.null",
+                                "SM": "SRR1066657_GSM1299413_WT_NR_A",
+                                "LB": "SRR1066657_GSM1299413_WT_NR_A",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -78,7 +103,12 @@
                             "sampleName": "SRR1066658_GSM1299414_WT_NR_B",
                             "trimStatus": "raw",
                             "readType": "single",
-                            "rgLine": "@RG\tID:SRR1066658_GSM1299414_WT_NR_B.null\tSM:SRR1066658_GSM1299414_WT_NR_B\tLB:SRR1066658_GSM1299414_WT_NR_B\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR1066658_GSM1299414_WT_NR_B.null",
+                                "SM": "SRR1066658_GSM1299414_WT_NR_B",
+                                "LB": "SRR1066658_GSM1299414_WT_NR_B",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz",
                         "SRR1066658_GSM1299414_WT_NR_B_Saccharomyces_cerevisiae_RNA-Seq_50000.fastq.gz.NOFILE:md5,d41d8cd98f00b204e9800998ecf8427e"
@@ -88,7 +118,12 @@
                             "sampleName": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null\tSM:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tLB:SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2.null",
+                                "SM": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "LB": "SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924569_GSM3073206_Saccharomyces_cerevisiae-AR_Biological_Repeat-2_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -98,7 +133,12 @@
                             "sampleName": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
                             "trimStatus": "raw",
                             "readType": "paired",
-                            "rgLine": "@RG\tID:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null\tSM:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tLB:SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1\tPL:ILLUMINA"
+                            "rgFields": {
+                                "ID": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1.null",
+                                "SM": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "LB": "SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1",
+                                "PL": "ILLUMINA"
+                            }
                         },
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000.fastq.gz",
                         "/trev-f/SRAlign-test/raw/rnaseq/data/reads/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000.fastq.gz"
@@ -106,6 +146,6 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-24T16:34:39.516404251"
+        "timestamp": "2023-10-30T13:46:02.432700881"
     }
 }


### PR DESCRIPTION
Different tools (especially alignment tools) require read group information to be specified in different ways. Here, the read group information is changed so that it is stored in a map in the metadata instead of a preformatted string.