### PR TITLE
change: standardize resource labels

### DIFF
--- a/conf/isaac.config
+++ b/conf/isaac.config
@@ -52,6 +52,10 @@ profiles {
                 cpus = { checkResources(4 * task.attempt, 'cpus') }
             }
 
+            withLabel: huge_cpu {
+                cpus = { checkResources(8 * task.attempt, 'cpus') }
+            }
+
             withLabel: sup_cpu {
                 cpus = { checkResources(12 * task.attempt, 'cpus') }
             }
@@ -83,6 +87,10 @@ profiles {
                 memory = { checkResources(16.GB * task.attempt, 'memory') }
             }
 
+            withLabel: huge_mem {
+                memory = { checkResources(32.GB * task.attempt, 'memory') }
+            }
+
             withLabel: sup_mem {
                 memory = { checkResources(48.GB * task.attempt, 'memory') }
             }
@@ -112,6 +120,10 @@ profiles {
             
             withLabel: big_time {
                 time = { checkResources(16.hour * task.attempt, 'time') }
+            }
+
+            withLabel: huge_time {
+                time = { checkResources(24.hour * task.attempt, 'time') }
             }
 
             withLabel: sup_time {

--- a/conf/isaac.config
+++ b/conf/isaac.config
@@ -15,9 +15,9 @@ profiles {
 
         params {
             // max resources
-            maxCpus   = 16
+            maxCpus   = 32
             maxMemory = '128.GB'
-            maxTime   = '48.h'
+            maxTime   = '72.h'
         }
 
         process {

--- a/conf/isaac.config
+++ b/conf/isaac.config
@@ -40,12 +40,24 @@ profiles {
             cpus = { checkResources(1 * task.attempt, 'cpus') }
 
             // dynamic numbers CPUs
+            withLabel: def_cpu {
+                cpus = { checkResources(1 * task.attempt, 'cpus') }
+            }
+
             withLabel: med_cpu {
                 cpus = { checkResources(2 * task.attempt, 'cpus') }
             }
 
             withLabel: big_cpu {
                 cpus = { checkResources(4 * task.attempt, 'cpus') }
+            }
+
+            withLabel: sup_cpu {
+                cpus = { checkResources(12 * task.attempt, 'cpus') }
+            }
+
+            withLabel: max_cpu {
+                cpus = { checkResources(24 * task.attempt, 'cpus') }
             }
 
             /*
@@ -56,11 +68,15 @@ profiles {
 
             // dynamic levels memory
             withLabel: lil_mem {
-                memory = { checkResources(1.GB * task.attempt, 'memory') }
+                memory = { checkResources(2.GB * task.attempt, 'memory') }
+            }
+
+            withLabel: def_mem {
+                memory = { checkResources(4.GB * task.attempt, 'memory') }
             }
 
             withLabel: med_mem {
-                memory = { checkResources(4.GB * task.attempt, 'memory') }
+                memory = { checkResources(8.GB * task.attempt, 'memory') }
             }
             
             withLabel: big_mem {
@@ -68,7 +84,7 @@ profiles {
             }
 
             withLabel: sup_mem {
-                memory = { checkResources(32.GB * task.attempt, 'memory') }
+                memory = { checkResources(48.GB * task.attempt, 'memory') }
             }
 
             withLabel: max_mem {
@@ -86,16 +102,24 @@ profiles {
                 time = { checkResources(30.min * task.attempt, 'time') }
             }
 
+            withLabel: def_time {
+                time = { checkResources(1.hour * task.attempt, 'time') }
+            }
+
             withLabel: med_time {
-                time = { checkResources(2.hour * task.attempt, 'time') }
+                time = { checkResources(4.hour * task.attempt, 'time') }
             }
             
             withLabel: big_time {
-                time = { checkResources(4.hour * task.attempt, 'time') }
+                time = { checkResources(16.hour * task.attempt, 'time') }
             }
 
             withLabel: sup_time {
-                time = { checkResources(16.hour * task.attempt, 'time') }
+                time = { checkResources(32.hour * task.attempt, 'time') }
+            }
+
+            withLabel: max_time {
+                time = { checkResources(48.hour * task.attempt, 'time') }
             }
         }
     }

--- a/modules/bwa_mem2_index.nf
+++ b/modules/bwa_mem2_index.nf
@@ -12,6 +12,7 @@ process bwa_mem2_index {
 
     label 'bwa_mem2'
 
+    label 'max_cpu'
     label 'max_mem'
     label 'big_time'
 

--- a/modules/bwa_mem2_mem.nf
+++ b/modules/bwa_mem2_mem.nf
@@ -13,7 +13,7 @@ process bwa_mem2_mem {
 
     label 'bwa_mem2'
 
-    label 'big_cpu'
+    label 'sup_cpu'
     label 'sup_mem'
     label 'sup_time'
 

--- a/modules/cutadapt.nf
+++ b/modules/cutadapt.nf
@@ -2,7 +2,10 @@ process cutadapt {
     tag "${metadata.sampleName}"
     
     label 'cutadapt'
-    label 'lil_mem'
+
+    label 'def_cpu'
+    label 'def_mem'
+    label 'def_time'
 
     publishDir(
         path:    "${params.publishDirReports}/reads/trim",

--- a/modules/fastp.nf
+++ b/modules/fastp.nf
@@ -5,6 +5,7 @@ process fastp {
 
     label 'med_cpu'
     label 'med_mem'
+    label 'med_time'
 
     publishDir(
         path:    "${params.publishDirReports}/reads/trim",

--- a/modules/fastqc.nf
+++ b/modules/fastqc.nf
@@ -3,7 +3,9 @@ process fastqc {
     
     label 'fastqc'
 
-    label 'lil_mem'
+    label 'med_cpu'
+    label 'def_mem'
+    label 'med_time'
 
     publishDir(
         path:    "${params.publishDirReports}/fastqc",

--- a/modules/gatk_MarkDuplicates.nf
+++ b/modules/gatk_MarkDuplicates.nf
@@ -3,7 +3,9 @@ process gatk_MarkDuplicates {
 
     label 'gatk'
 
-    label 'med_mem'
+    label 'big_cpu'
+    label 'big_mem'
+    label 'med_time'
 
     publishDir(
         path:    "${params.publishDirData}/alignments",

--- a/modules/gatk_MergeSamFiles.nf
+++ b/modules/gatk_MergeSamFiles.nf
@@ -3,6 +3,10 @@ process gatk_MergeSamFiles {
 
     label 'gatk'
 
+    label 'def_cpu'
+    label 'def_mem'
+    label 'def_time'
+
     input:
         tuple val(metadata), path(bams), path(bais)
 

--- a/modules/gunzip.nf
+++ b/modules/gunzip.nf
@@ -3,7 +3,9 @@ process gunzip {
 
     label 'base'
 
+    label 'def_cpu'
     label 'lil_mem'
+    label 'lil_time'
 
     input:
         path archive

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -3,7 +3,9 @@ process multiqc {
     
     label 'multiqc'
 
-    label 'med_mem'
+    label 'def_cpu'
+    label 'def_mem'
+    label 'lil_time'
 
     publishDir(
         path:    "${params.publishDirReports}/multiqc/${fileName}",

--- a/modules/samtools_faidx.nf
+++ b/modules/samtools_faidx.nf
@@ -3,6 +3,10 @@ process samtools_faidx {
 
     label 'samtools'
 
+    label 'def_cpu'
+    label 'lil_mem'
+    label 'lil_time'
+
     input:
         path fasta
 

--- a/modules/samtools_flagstat.nf
+++ b/modules/samtools_flagstat.nf
@@ -3,6 +3,10 @@ process samtools_flagstat {
 
     label 'samtools'
 
+    label 'def_cpu'
+    label 'lil_mem'
+    label 'lil_time'
+
     publishDir(
         path:    "${params.publishDirReports}/alignments",
         mode:    "${params.publishMode}",

--- a/modules/samtools_idxstats.nf
+++ b/modules/samtools_idxstats.nf
@@ -3,6 +3,10 @@ process samtools_idxstats {
 
     label 'samtools'
 
+    label 'def_cpu'
+    label 'lil_mem'
+    label 'lil_time'
+
     publishDir(
         path:    "${params.publishDirReports}/alignments",
         mode:    "${params.publishMode}",

--- a/modules/samtools_sort_index.nf
+++ b/modules/samtools_sort_index.nf
@@ -11,6 +11,10 @@ process samtools_sort_index {
 
     label 'samtools'
 
+    label 'def_cpu'
+    label 'def_mem'
+    label 'lil_time'
+
     input:
         tuple val(metadata), path(alignments)
 

--- a/modules/samtools_stats.nf
+++ b/modules/samtools_stats.nf
@@ -3,6 +3,10 @@ process samtools_stats {
 
     label 'samtools'
 
+    label 'def_cpu'
+    label 'lil_mem'
+    label 'def_time'
+
     publishDir(
         path:    "${params.publishDirReports}/alignments",
         mode:    "${params.publishMode}",

--- a/modules/sequencing_depth.nf
+++ b/modules/sequencing_depth.nf
@@ -12,6 +12,10 @@ process sequencing_depth {
 
     label 'biopython'
 
+    label 'def_cpu'
+    label 'lil_mem'
+    label 'med_time'
+
     input:
         tuple val(metadata), path(reads1), path(reads2)
         path fai

--- a/modules/star_genomeGenerate.nf
+++ b/modules/star_genomeGenerate.nf
@@ -3,9 +3,9 @@ process star_genomeGenerate {
 
     label 'star'
 
-    label 'big_cpu'
+    label 'sup_cpu'
     label 'sup_mem'
-    label 'big_time'
+    label 'med_time'
 
     input:
         path genome

--- a/modules/star_runMapping.nf
+++ b/modules/star_runMapping.nf
@@ -13,9 +13,9 @@ process star_runMapping {
     
     label 'star'
 
-    label 'big_cpu'
-    label 'sup_mem'
-    label 'sup_time'
+    label 'huge_cpu'
+    label 'huge_mem'
+    label 'huge_time'
 
     input:
         tuple val(metadata), path(reads1), path(reads2)


### PR DESCRIPTION
Give all processes a resource label.
Make more reasonable resource requests based on the pipeline runs I've seen so far.

Closes #54